### PR TITLE
Fix libmariadb dependencies and install pgmagick from package not source

### DIFF
--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -27,7 +27,7 @@ apt-get install --yes --quiet --no-install-recommends \
     libpoppler-cpp-dev pkg-config python3-dev ghostscript
 
 # Install pip dependencies that are either needed globally, or _very_ expensive to build
-apt-get install python-pgmagick
-pip install pgmagick pipenv
+pip install pipenv
+pip install pgmagick
 
 npm i -g yarn

--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -28,6 +28,7 @@ apt-get install --yes --quiet --no-install-recommends \
 
 # Install pip dependencies that are either needed globally, or _very_ expensive to build
 pip install pipenv
-pip install pgmagick
+
+apt get install python3-pgmagick
 
 npm i -g yarn

--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -7,7 +7,7 @@ apt-get install --yes --quiet --no-install-recommends \
     build-essential \
     libpq-dev \
     libmariadb-dev \
-    ibmariadb-dev-compat \
+    libmariadb-dev-compat \
     libjpeg62-turbo-dev \
     zlib1g-dev \
     libwebp-dev \

--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -29,6 +29,6 @@ apt-get install --yes --quiet --no-install-recommends \
 # Install pip dependencies that are either needed globally, or _very_ expensive to build
 pip install pipenv
 
-apt get install python3-pgmagick
+apt-get install python3-pgmagick
 
 npm i -g yarn

--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -1,6 +1,8 @@
 set -e
 
 apt-get update -y
+
+# Install required packages
 apt-get install --yes --quiet --no-install-recommends \
     curl \
     git \

--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -6,7 +6,8 @@ apt-get install --yes --quiet --no-install-recommends \
     git \
     build-essential \
     libpq-dev \
-    libmariadbclient-dev \
+    libmariadb-dev \
+    ibmariadb-dev-compat \
     libjpeg62-turbo-dev \
     zlib1g-dev \
     libwebp-dev \

--- a/.bin/prepare.sh
+++ b/.bin/prepare.sh
@@ -27,6 +27,7 @@ apt-get install --yes --quiet --no-install-recommends \
     libpoppler-cpp-dev pkg-config python3-dev ghostscript
 
 # Install pip dependencies that are either needed globally, or _very_ expensive to build
+apt-get install python-pgmagick
 pip install pgmagick pipenv
 
 npm i -g yarn


### PR DESCRIPTION
When building this container from fresh, Docker stopped on adding `libmariadbclient-dev` as no package of this name existed. 

This is likely because the release the new version of Debian in the last few weeks, that is the basis for upstream containers. This new stable version of Debian (previously code named `bullseye`), released on the [14th of August](https://www.debian.org/News/2021/20210814) deprecates this package in favour of ones called `libmariadb-dev-compat` and so on.

https://packages.debian.org/search?searchon=names&keywords=libmariadbclient-dev

In addition, this PR dispenses with the need to build `pgmagick` from source. 

This was pure pragmatism, as I couldn't get this going, as it wasn't compiling at the linking stage for whatever reason. However this does make for a better developer experience all in and a faster deploy time on Digital Ocean.

I didn't push direct to `main` as was unclear of the upstream uses of this image and didn't want to cause breakages. I can monkey patch this locally to get moving.

Also, pull requests are a good thing!